### PR TITLE
Switch to more lightweight PR template

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,7 +1,1 @@
-Fixes #
-
-## Proposed Changes
-
-  -
-  -
-  -
+# 


### PR DESCRIPTION
Fixes last PRs description being primarily empty containing only the template content itself.

E.g. #17, #16, #15, #14, #13, #12, ...